### PR TITLE
FEA-3357 - Fixed title attribute display

### DIFF
--- a/src/js/controls/Tab.js
+++ b/src/js/controls/Tab.js
@@ -71,8 +71,9 @@ lm.utils.copy( lm.controls.Tab.prototype, {
 	 * @param {String} title can contain html
 	 */
 	setTitle: function( title ) {
-		this.element.attr( 'title', lm.utils.stripTags( title ) );
-		this.titleElement.html( title );
+		var safeTitle = lm.utils.stripTags( title );
+		this.titleElement.html( safeTitle );
+		this.element.attr( 'title', this.titleElement.text() );
 	},
 
 	/**


### PR DESCRIPTION
Made title safe for both tab content and title attribute
Fixed attribute title when title has entities

Didn't run `gulp build` to build all up
not sure about the procedure of bumping up versions 
or if we bulk update at the end of the sprint

If anything needed, ill gladly update it